### PR TITLE
Fix broken MD link in BasicFodyBasicFodyAddin readme

### DIFF
--- a/BasicFodyAddin/readme.md
+++ b/BasicFodyAddin/readme.md
@@ -2,7 +2,7 @@
 
 ![Icon](https://raw.githubusercontent.com/Fody/Home/master/BasicFodyAddin/package_icon.png)
 
-This is a simple solution used to illustrate how to [write a Fody addin](/pages/write-an-addin.md).
+This is a simple solution used to illustrate how to [write a Fody addin](/pages/addin-development.md).
 
 
 ## Usage
@@ -35,7 +35,7 @@ Add `<BasicFodyAddin/>` to [FodyWeavers.xml](/pages/configuration.md#fodyweavers
 
 ## The moving parts
 
-See [writing an addin](/pages/write-an-addin.md)
+See [writing an addin](/pages/addin-development.md)
 
 
 ## Icon


### PR DESCRIPTION
#### You should already be a Patron

I don't use Fody; I just saw the project on Twitter and started browsing the docs.

#### Guidance

Fixing links is 100% risk free and is pure goodness for a project.


#### Description

Commit 6aef4b626c7b02 renamed /pages/write-an-addin.md to /pages/addin-development.md
Update those links in /BasicFodyAddin/readme.md


#### The solution

Fix the links.


#### Todos

 * [X] Related issues **N/A**
 * [X] Tests **N/A**
 * [X] Documentation