### PR TITLE
Changed dead `Open-Source Maintainers are Jerks` link from Vimeo to working YouTube link

### DIFF
--- a/pages/licensing-patron-faq.md
+++ b/pages/licensing-patron-faq.md
@@ -24,7 +24,7 @@ It is an honesty system with no code or legal enforcement. When raising an issue
 
 ## Why charge for open source?
 
- * [Open-Source Maintainers are Jerks | Nick Randolph & Geoffrey Huntley](https://vimeo.com/296579853)
+ * [Open-Source Maintainers are Jerks | Nick Randolph & Geoffrey Huntley](https://www.youtube.com/watch?v=Mm_RuObpeGo)
  * [FOSS is free as in toilet | Geoffroy Couprie](http://unhandledexpression.com/general/2018/11/27/foss-is-free-as-in-toilet.html)
  * [How to Charge for Open Source | Mike Perham](https://www.mikeperham.com/2015/11/23/how-to-charge-for-your-open-source/)
  * [Sustain OSS: The Report](https://sustainoss.org/assets/pdf/SustainOSS-west-2017-report.pdf)


### PR DESCRIPTION
#### Guidance

Should note that i just came across this repository when browsing the sources of some project on github, not a patron here


#### Description

The `Licensing/Patron FAQ` contained a dead link to a vimeo page.


#### The solution

Replaced the vimeo link with a youtube one

as alternative, the video may also be removed, tho given that this section is supposed to be provocative and the video title is too, it should be kept with the youtube link


#### Todos

- Maybe choose a "safe" host for theese things, where the video will stay as long as this project exists